### PR TITLE
Define new `package_manager.commands` schema

### DIFF
--- a/data/arch.mapping.json
+++ b/data/arch.mapping.json
@@ -388,16 +388,24 @@
   "package_managers": [
     {
       "name": "pacman",
-      "install_command": [
-        "pacman",
-        "-Syu",
-        "--noconfirm"
-      ],
-      "query_command": [
-        "pacman",
-        "-Q"
-      ],
-      "requires_elevation": "install",
+      "commands": {
+        "install": {
+          "command": [
+            "pacman",
+            "-Syu",
+            "--noconfirm",
+            "{}"
+          ],
+          "requires_elevation": true
+        },
+        "query": {
+          "command": [
+            "pacman",
+            "-Q",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/chocolatey.mapping.json
+++ b/data/chocolatey.mapping.json
@@ -290,15 +290,23 @@
   "package_managers": [
     {
       "name": "choco",
-      "install_command": [
-        "choco",
-        "install"
-      ],
-      "query_command": [
-        "choco",
-        "list",
-        "--local-only"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "choco",
+            "install",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "choco",
+            "list",
+            "--local-only",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/conan.mapping.json
+++ b/data/conan.mapping.json
@@ -358,16 +358,24 @@
   "package_managers": [
     {
       "name": "conan",
-      "install_command": [
-        "conan",
-        "install",
-        "--requires"
-      ],
-      "query_command": [
-        "conan",
-        "get",
-        "--check"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "conan",
+            "install",
+            "--requires",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "conan",
+            "get",
+            "--check",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/conda-forge.mapping.json
+++ b/data/conda-forge.mapping.json
@@ -564,18 +564,26 @@
   "package_managers": [
     {
       "name": "conda",
-      "install_command": [
-        "conda",
-        "install",
-        "--yes",
-        "--channel=conda-forge",
-        "--strict-channel-priority"
-      ],
-      "query_command": [
-        "conda",
-        "list",
-        "-f"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "conda",
+            "install",
+            "--yes",
+            "--channel=conda-forge",
+            "--strict-channel-priority",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "conda",
+            "list",
+            "-f",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {
         "and": ",",
         "arbitrary": "==",
@@ -591,18 +599,26 @@
     },
     {
       "name": "mamba",
-      "install_command": [
-        "mamba",
-        "install",
-        "--yes",
-        "--channel=conda-forge",
-        "--channel-priority=strict"
-      ],
-      "query_command": [
-        "mamba",
-        "list",
-        "-f"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "mamba",
+            "install",
+            "--yes",
+            "--channel=conda-forge",
+            "--channel-priority=strict",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "mamba",
+            "list",
+            "-f",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {
         "and": ",",
         "arbitrary": "==",
@@ -618,18 +634,26 @@
     },
     {
       "name": "micromamba",
-      "install_command": [
-        "micromamba",
-        "install",
-        "--yes",
-        "--channel=conda-forge",
-        "--channel-priority=strict"
-      ],
-      "query_command": [
-        "micromamba",
-        "list",
-        "-f"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "micromamba",
+            "install",
+            "--yes",
+            "--channel=conda-forge",
+            "--channel-priority=strict",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "micromamba",
+            "list",
+            "-f",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {
         "and": ",",
         "arbitrary": "==",
@@ -645,15 +669,22 @@
     },
     {
       "name": "pixi",
-      "install_command": [
-        "pixi",
-        "add"
-      ],
-      "query_command": [
-        "pixi",
-        "list",
-        "^{}$"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "pixi",
+            "add",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "pixi",
+            "list",
+            "^{}$"
+          ]
+        }
+      },
       "version_operators": {
         "and": ",",
         "arbitrary": "==",

--- a/data/fedora.mapping.json
+++ b/data/fedora.mapping.json
@@ -662,16 +662,24 @@
   "package_managers": [
     {
       "name": "dnf",
-      "install_command": [
-        "dnf",
-        "install",
-        "-y"
-      ],
-      "query_command": [
-        "rpm",
-        "-q"
-      ],
-      "requires_elevation": "install",
+      "commands": {
+        "install": {
+          "command": [
+            "dnf",
+            "install",
+            "-y",
+            "{}"
+          ],
+          "requires_elevation": true
+        },
+        "query": {
+          "command": [
+            "rpm",
+            "-q",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/gentoo.mapping.json
+++ b/data/gentoo.mapping.json
@@ -385,25 +385,41 @@
   "package_managers": [
     {
       "name": "pkgcore",
-      "install_command": [
-        "pmerge"
-      ],
-      "query_command": [
-        "pkgcore",
-        "search",
-        "-I"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "pmerge"
+          ],
+          "requires_elevation": true
+        },
+        "query": {
+          "command": [
+            "pkgcore",
+            "search",
+            "-I"
+          ]
+        }
+      },
       "version_operators": {}
     },
     {
       "name": "portage",
-      "install_command": [
-        "emerge"
-      ],
-      "query_command": [
-        "qlist",
-        "-I"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "emerge",
+            "{}"
+          ],
+          "requires_elevation": true
+        },
+        "query": {
+          "command": [
+            "qlist",
+            "-I",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/homebrew.mapping.json
+++ b/data/homebrew.mapping.json
@@ -364,15 +364,23 @@
   "package_managers": [
     {
       "name": "brew",
-      "install_command": [
-        "brew",
-        "install"
-      ],
-      "query_command": [
-        "brew",
-        "list",
-        "--formula"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "brew",
+            "install",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "brew",
+            "list",
+            "--formula",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/nix.mapping.json
+++ b/data/nix.mapping.json
@@ -416,23 +416,38 @@
   "package_managers": [
     {
       "name": "nix-env",
-      "install_command": [
-        "nix-env",
-        "-iA"
-      ],
-      "query_command": [
-        "nix-env",
-        "-q"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "nix-env",
+            "-iA",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "nix-env",
+            "-q",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     },
     {
       "name": "nix-shell",
-      "install_command": [
-        "nix-shell",
-        "-p"
-      ],
-      "query_command": [],
+      "commands": {
+        "install": {
+          "command": [
+            "nix-shell",
+            "-p",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": []
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/pypi.mapping.json
+++ b/data/pypi.mapping.json
@@ -296,30 +296,46 @@
   "package_managers": [
     {
       "name": "pip",
-      "install_command": [
-        "pip",
-        "install",
-        "--yes"
-      ],
-      "query_command": [
-        "pip",
-        "show"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "pip",
+            "install",
+            "--yes",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "pip",
+            "show",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     },
     {
       "name": "uv",
-      "install_command": [
-        "uv",
-        "pip",
-        "install",
-        "--yes"
-      ],
-      "query_command": [
-        "uv",
-        "pip",
-        "show"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "uv",
+            "pip",
+            "install",
+            "--yes",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "uv",
+            "pip",
+            "show",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/scoop.mapping.json
+++ b/data/scoop.mapping.json
@@ -386,14 +386,22 @@
   "package_managers": [
     {
       "name": "scoop",
-      "install_command": [
-        "scoop",
-        "install"
-      ],
-      "query_command": [
-        "scoop",
-        "list"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "scoop",
+            "install",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "scoop",
+            "list",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/spack.mapping.json
+++ b/data/spack.mapping.json
@@ -475,14 +475,22 @@
   "package_managers": [
     {
       "name": "spack",
-      "install_command": [
-        "spack",
-        "install"
-      ],
-      "query_command": [
-        "spack",
-        "find"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "spack",
+            "install",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "spack",
+            "find",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/ubuntu.mapping.json
+++ b/data/ubuntu.mapping.json
@@ -566,29 +566,45 @@
   "package_managers": [
     {
       "name": "apt",
-      "install_command": [
-        "apt",
-        "install",
-        "--yes"
-      ],
-      "query_command": [
-        "dpkg-query",
-        "-W"
-      ],
-      "requires_elevation": "install"
+      "commands": {
+        "install": {
+          "command": [
+            "apt",
+            "install",
+            "--yes",
+            "{}"
+          ],
+          "requires_elevation": true
+        },
+        "query": {
+          "command": [
+            "dpkg-query",
+            "-W",
+            "{}"
+          ]
+        }
+      }
     },
     {
       "name": "apt-get",
-      "install_command": [
-        "apt-get",
-        "install",
-        "--yes"
-      ],
-      "query_command": [
-        "dpkg-query",
-        "-W"
-      ],
-      "requires_elevation": "install",
+      "commands": {
+        "install": {
+          "command": [
+            "apt-get",
+            "install",
+            "--yes",
+            "{}"
+          ],
+          "requires_elevation": true
+        },
+        "query": {
+          "command": [
+            "dpkg-query",
+            "-W",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/vcpkg.mapping.json
+++ b/data/vcpkg.mapping.json
@@ -373,14 +373,22 @@
   "package_managers": [
     {
       "name": "vcpkg",
-      "install_command": [
-        "vcpkg",
-        "install"
-      ],
-      "query_command": [
-        "vcpkg",
-        "list"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "vcpkg",
+            "install",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "vcpkg",
+            "list",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/data/winget.mapping.json
+++ b/data/winget.mapping.json
@@ -305,16 +305,24 @@
   "package_managers": [
     {
       "name": "winget",
-      "install_command": [
-        "winget",
-        "install",
-        "--exact",
-        "--id"
-      ],
-      "query_command": [
-        "winget",
-        "list"
-      ],
+      "commands": {
+        "install": {
+          "command": [
+            "winget",
+            "install",
+            "--exact",
+            "--id",
+            "{}"
+          ]
+        },
+        "query": {
+          "command": [
+            "winget",
+            "list",
+            "{}"
+          ]
+        }
+      },
       "version_operators": {}
     }
   ]

--- a/pixi.lock
+++ b/pixi.lock
@@ -189,12 +189,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/3f/945ef7ab14dc4f9d7f40288d2df998d1837ee0888ec3659c813487572faa/pip-25.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/0c/246389572f52cba2c736be8c646f2f868f1b9458a8e6d5fc675656b3e01b/pypi_json-0.4.0-py3-none-any.whl
+      - pypi: git+https://github.com/jaimergp/pyproject-external.git#a893e9bb2bdb9ca66e4391e8c40f823373235b59
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl
-      - pypi: ../pyproject-external
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/altair-5.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -370,12 +370,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/3f/945ef7ab14dc4f9d7f40288d2df998d1837ee0888ec3659c813487572faa/pip-25.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/0c/246389572f52cba2c736be8c646f2f868f1b9458a8e6d5fc675656b3e01b/pypi_json-0.4.0-py3-none-any.whl
+      - pypi: git+https://github.com/jaimergp/pyproject-external.git#a893e9bb2bdb9ca66e4391e8c40f823373235b59
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl
-      - pypi: ../pyproject-external
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/altair-5.5.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -551,12 +551,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/3f/945ef7ab14dc4f9d7f40288d2df998d1837ee0888ec3659c813487572faa/pip-25.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/0c/246389572f52cba2c736be8c646f2f868f1b9458a8e6d5fc675656b3e01b/pypi_json-0.4.0-py3-none-any.whl
+      - pypi: git+https://github.com/jaimergp/pyproject-external.git#a893e9bb2bdb9ca66e4391e8c40f823373235b59
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl
-      - pypi: ../pyproject-external
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/altair-5.5.0-pyhd8ed1ab_1.conda
@@ -724,12 +724,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b7/3f/945ef7ab14dc4f9d7f40288d2df998d1837ee0888ec3659c813487572faa/pip-25.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/0c/246389572f52cba2c736be8c646f2f868f1b9458a8e6d5fc675656b3e01b/pypi_json-0.4.0-py3-none-any.whl
+      - pypi: git+https://github.com/jaimergp/pyproject-external.git#a893e9bb2bdb9ca66e4391e8c40f823373235b59
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl
-      - pypi: ../pyproject-external
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -6687,10 +6687,9 @@ packages:
   - packaging>=21.0
   - requests>=2.26.0
   requires_python: '>=3.6'
-- pypi: ../pyproject-external
+- pypi: git+https://github.com/jaimergp/pyproject-external.git#a893e9bb2bdb9ca66e4391e8c40f823373235b59
   name: pyproject-external
-  version: 0.1.1.dev9+ga00c2d6.d20250806
-  sha256: be04808afd8f0470e0b176f41cffbd8df3c0963d1bcf7617f85c7320fa7de5e0
+  version: 0.1.2.dev1+ga893e9b
   requires_dist:
   - build
   - click<8.2
@@ -6709,7 +6708,6 @@ packages:
   - typer
   - typing-extensions ; python_full_version < '3.11'
   requires_python: '>=3.10'
-  editable: true
 - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
   name: pyproject-hooks
   version: 1.2.0

--- a/schemas/external-mapping.schema.json
+++ b/schemas/external-mapping.schema.json
@@ -169,40 +169,8 @@
           "title": "Name",
           "type": "string"
         },
-        "install_command": {
-          "description": "Command that must be used to install the given package(s). Each argument must be provided as a\nseparate string, as in `subprocess.run`. Use `{}` as a placeholder where the package specs\nmust be injected, if needed. If `{}` is not present, they will be added at the end.",
-          "items": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "title": "Install Command",
-          "type": "array"
-        },
-        "query_command": {
-          "description": "Command to check whether a package is installed. Each argument must be provided as a\nseparate string, as in `subprocess.run`. The `{}` placeholder will be replaced by\na single package spec, if needed. Otherwise, the package specifier will be added at the end.",
-          "items": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "title": "Query Command",
-          "type": "array"
-        },
-        "requires_elevation": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "enum": [
-                "install",
-                "query"
-              ],
-              "type": "string"
-            }
-          ],
-          "default": false,
-          "description": "Whether the install and query commands require elevated permissions to run. Use `True`\nto require on all commands, `False` for none. `install` and `query` can be used individually\nto only require elevation on one of them.",
-          "title": "Requires Elevation"
+        "commands": {
+          "$ref": "#/$defs/PackageManagerCommands"
         },
         "version_operators": {
           "$ref": "#/$defs/VersionOperators",
@@ -223,10 +191,60 @@
       },
       "required": [
         "name",
-        "install_command",
-        "query_command"
+        "commands"
       ],
       "title": "PackageManager",
+      "type": "object"
+    },
+    "PackageManagerCommand": {
+      "additionalProperties": false,
+      "description": "Command template plus its elevation requirements.",
+      "properties": {
+        "command": {
+          "default": [],
+          "description": "Command template, as expected by `subprocess.run`. Use `{}` as a placeholder for package(s).",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Command",
+          "type": "array"
+        },
+        "requires_elevation": {
+          "default": false,
+          "description": "Whether the command requires elevated permissions to run.",
+          "title": "Requires Elevation",
+          "type": "boolean"
+        }
+      },
+      "title": "PackageManagerCommand",
+      "type": "object"
+    },
+    "PackageManagerCommands": {
+      "additionalProperties": false,
+      "description": "Command templates needed to execute certain operations with this package manager",
+      "properties": {
+        "install": {
+          "$ref": "#/$defs/PackageManagerCommand",
+          "description": "Command that must be used to install the given package(s). The tool must accept several\npackages in the same command. Each argument must be provided as a separate string, as\nin `subprocess.run`. Use `{}` as a placeholder where the package spec(s) must be injected.\nThe placeholder can only appear once in the whole list and will be replaced once per package.\nFor example, given the names `foo` and `bar`, `[\"pkg\", \"install\", \"{}\"]` would become\n`pkg install foo bar`, and `[\"pkg\", \"install\", \"--spec={}\"]` would become\n`pkg install --spec=foo --spec=bar`."
+        },
+        "query": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PackageManagerCommand"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Command to check whether a package is installed. The tool must only accept one package at a\ntime. Each argument must be provided as a separate string, as in `subprocess.run`. The `{}`\nplaceholder will be replaced by the single package. An empty list means no query command is\navailable for this package manager."
+        }
+      },
+      "required": [
+        "install"
+      ],
+      "title": "PackageManagerCommands",
       "type": "object"
     },
     "SpecsDict": {


### PR DESCRIPTION
Changes:

* `install_command` and `query_command` are now `commands["install"]` and `commands["query"]`, respectively
* `requires_elevation` has moved inside `commands[*]`
* Placeholder behavior is better documented
* Install command is multi-arg, query command is single-arg