### PR TITLE
gentoo: Use standard `portageq` tool to query packages

### DIFF
--- a/data/gentoo.mapping.json
+++ b/data/gentoo.mapping.json
@@ -416,8 +416,9 @@
         },
         "query": {
           "command": [
-            "qlist",
-            "-I",
+            "portageq",
+            "has_version",
+            "/",
             "{}"
           ]
         }


### PR DESCRIPTION
Use the `portageq` tool from Portage itself to query installed packages rather than the third-party `qlist` tool.  It has the extra advantage of matching the exact package name rather than string search.