### PR TITLE
identify `generic/llvm` with conda-forge's `llvmdev`

### DIFF
--- a/data/conda-forge.mapping.json
+++ b/data/conda-forge.mapping.json
@@ -546,7 +546,10 @@
     {
       "id": "dep:virtual/interface/lapack",
       "description": "The default implementation for LAPACK",
-      "specs": ["liblapack", "liblapacke"],
+      "specs": [
+        "liblapack",
+        "liblapacke"
+      ],
       "urls": {
         "feedstock": "https://github.com/conda-forge/lapack-feedstock"
       }


### PR DESCRIPTION
Not sure if this is the right way to fix it, but for the "Development headers and libraries for LLVM" (more specifically, what's built out of the `/llvm` [folder](https://github.com/llvm/llvm-project/tree/main/llvm) in the overall LLVM project), the right conda-forge package would be `llvmdev`.