### PR TITLE
Update vcpkg.mapping.json to remove vcpkg-cmake as a vcpkg package for cmake

### DIFF
--- a/data/vcpkg.mapping.json
+++ b/data/vcpkg.mapping.json
@@ -20,10 +20,7 @@
     {
       "id": "dep:generic/cmake",
       "description": "Not available",
-      "specs": "vcpkg-cmake",
-      "urls": {
-        "vcpkg.io": "https://vcpkg.io/en/package/vcpkg-cmake"
-      }
+      "specs": ""
     },
     {
       "id": "dep:generic/freetype",

--- a/data/vcpkg.mapping.json
+++ b/data/vcpkg.mapping.json
@@ -20,7 +20,7 @@
     {
       "id": "dep:generic/cmake",
       "description": "Not available",
-      "specs": ""
+      "specs": []
     },
     {
       "id": "dep:generic/freetype",


### PR DESCRIPTION
Thanks for all the work on this! 

By looking at the `vcpkg` metadata, I noticed that `vcpkg-cmake` vcpkg package is listed as a provider for CMake. However, the `vcpkg-cmake` is just a collection of cmake macros used internally by vcpkg portfiles, it does not provide CMake, see https://github.com/microsoft/vcpkg/blob/2025.09.17/ports/vcpkg-cmake/portfile.cmake and https://github.com/microsoft/vcpkg/tree/2025.09.17/ports/vcpkg-cmake .

`vcpkg` itself has a way to download binary version of a few tools (see https://github.com/microsoft/vcpkg-tool/blob/2025-09-03/include/vcpkg/tools.h#L17-L37) it the system version is not new enough, but that is different from the port mechanism, as it is available via `vcpkg fetch cmake` or `vcpkg fetch ninja`. As this system can be used also for `ninja`, and currently the ninja section in this mapping have `"specs": ""`, I think it make sense to have the same `"specs": ""` also for CMake.